### PR TITLE
Switch to CDN host

### DIFF
--- a/tools/chocolateyinstall.ps1
+++ b/tools/chocolateyinstall.ps1
@@ -1,6 +1,6 @@
 ﻿$packageName = 'p4v'
 $version = 'r24.4'
-$baseurl = "https://filehost.perforce.com/perforce/$version"
+$baseurl = "https://cdist2.perforce.com/perforce/$version"
 $url = "$baseurl/bin.ntx64/p4vinst64.exe"
 # $checksum64 = ((Invoke-WebRequest "$baseurl/bin.ntx64/SHA256SUMS" -UseBasicParsing).RawContent.ToString().Split() | Select-String -Pattern 'p4vinst64.exe' -SimpleMatch -Context 1,0 ).ToString().Trim().Split()[0]
 $checksum64 = '3f68f61863209320387bc70b8972b1246ebf23e95872c3ab0928e77e67930e97'


### PR DESCRIPTION
filehost.perforce.com appears to be a centralised single host in the US West Coast, whereas cdist2.perforce.com is Cloudfront CDNed.

Probably better to use the CDN domains?